### PR TITLE
Use internal action to get commit SHA

### DIFF
--- a/.github/actions/short-sha/action.yaml
+++ b/.github/actions/short-sha/action.yaml
@@ -4,10 +4,9 @@ runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
-    - name: "Hello World"
+    - name: Output commit SHA
       shell: bash
       run: |
-        echo 'Hello World'
         SHA=$(git show --format='%h' --no-patch)
         echo "value=$SHA" >> "$GITHUB_OUTPUT"
         echo "$SHA"

--- a/.github/actions/short-sha/action.yaml
+++ b/.github/actions/short-sha/action.yaml
@@ -1,0 +1,12 @@
+name: output-sha
+description: Outputs Short commit SHA.
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+    - name: "Hello World"
+      run: |
+        echo 'Hello World'
+        SHA=$(git show --format='%h' --no-patch)
+        echo "value=$SHA" >> "$GITHUB_OUTPUT"
+        echo "$SHA"

--- a/.github/actions/short-sha/action.yaml
+++ b/.github/actions/short-sha/action.yaml
@@ -1,11 +1,16 @@
 name: output-sha
 description: Outputs Short commit SHA.
+outputs:
+  SHA:
+    value: ${{ steps.sha.outputs.SHA }}
+    description: commit SHA value.
 runs:
   using: composite
   steps:
     - uses: actions/checkout@v4
     - name: Output commit SHA
       shell: bash
+      id: sha
       run: |
         SHA=$(git show --format='%h' --no-patch)
         echo "value=$SHA" >> "$GITHUB_OUTPUT"

--- a/.github/actions/short-sha/action.yaml
+++ b/.github/actions/short-sha/action.yaml
@@ -5,6 +5,7 @@ runs:
   steps:
     - uses: actions/checkout@v4
     - name: "Hello World"
+      shell: bash
       run: |
         echo 'Hello World'
         SHA=$(git show --format='%h' --no-patch)

--- a/.github/actions/short-sha/action.yaml
+++ b/.github/actions/short-sha/action.yaml
@@ -2,7 +2,7 @@ name: output-sha
 description: Outputs Short commit SHA.
 outputs:
   SHA:
-    value: ${{ steps.sha.outputs.SHA }}
+    value: ${{ steps.sha.outputs.sha }}
     description: commit SHA value.
 runs:
   using: composite
@@ -13,5 +13,5 @@ runs:
       id: sha
       run: |
         SHA=$(git show --format='%h' --no-patch)
-        echo "value=$SHA" >> "$GITHUB_OUTPUT"
+        echo "sha=$SHA" >> "$GITHUB_OUTPUT"
         echo "$SHA"

--- a/.github/pinact.yaml
+++ b/.github/pinact.yaml
@@ -1,0 +1,3 @@
+files:
+  - pattern: '^(.*/)*action\\.yaml$'
+  - pattern: '^\.github/workflows/.*\\.yaml$'

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Output SHA
-        uses: benjlevesque/short-sha@599815c8ee942a9616c92bcfb4f947a3b670ab0b # v3.0.0
+        uses: ./.github/actions/short-sha
         id: short-sha
       - name: Download artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
@@ -32,7 +32,7 @@ jobs:
           echo "value=$TAG_NAME" >> "$GITHUB_OUTPUT"
           echo "$TAG_NAME"
         env:
-          SHA: ${{ steps.short-sha.outputs.sha }}
+          SHA: ${{ steps.short-sha.outputs.SHA }}
       - name: Create release
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - name: Output SHA
-        uses: benjlevesque/short-sha@599815c8ee942a9616c92bcfb4f947a3b670ab0b # v3.0.0
+        uses: ./.github/actions/short-sha
         id: short-sha
       - name: Set plugin ver with SHA commit
         run: |
           sed -ri "s/^(versionSuffix=).*/\1sha-${SHA}/" gradle.properties || :
         env:
-          SHA: ${{ steps.short-sha.outputs.sha }}
+          SHA: ${{ steps.short-sha.outputs.SHA }}
       - name: Set up JDK
         uses: actions/setup-java@2dfa2011c5b2a0f1489bf9e433881c92c1631f88 # v4.3.0
         with:

--- a/.github/workflows/lint-actions.yaml
+++ b/.github/workflows/lint-actions.yaml
@@ -35,6 +35,9 @@ jobs:
       - name: Run ghalint
         run: |
           ghalint -c ./.github/ghalint.yaml run
+      - name: Run ghalint for actions
+        run: |
+          ghalint run-action
   actionlint:
     runs-on: ubuntu-22.04
     timeout-minutes: 2

--- a/.github/workflows/lint-actions.yaml
+++ b/.github/workflows/lint-actions.yaml
@@ -2,7 +2,7 @@ name: Lint GitHub Actions
 on:
   push:
     paths:
-      - .github/workflows/**
+      - .github/**
 permissions: {}
 jobs:
   pinact:


### PR DESCRIPTION
- **ci: add short-sha action**
- **ci: use internal action to get short sha**
- **ci: set shell in action**
- **ci: fix step title**
- **ci: run action linter on pushed to .github**
- **ci: set output for composite action**
- **ci: fix output key**
- **ci: run linter for actions**
